### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,96 @@
+name: Publish Docker image
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'master'
+
+env:
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Uses the `docker/login-action` action to log in to the Docker Hub registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      # - name: Log in to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+            # ${{ env.IMAGE_NAME }}
+          images: |
+            ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            # tagged releases
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Support everything in https://hub.docker.com/_/python
+          platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation for GHCR
+        uses: actions/attest-build-provenance@v2
+        id: attest
+        with:
+          subject-name: ghcr.io/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,8 +84,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Support everything in https://hub.docker.com/_/python
-          # linux/386, linux/ppc64le, linux/arm/v7 removed due to compatibility in pip
-          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8, linux/s390x
+          # linux/386, linux/ppc64le, linux/arm/v6, linux/arm/v7 removed due to compatibility in pip
+          platforms: linux/amd64, linux/arm64/v8, linux/s390x
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation for GHCR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,8 +84,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Support everything in https://hub.docker.com/_/python
-          # linux/386, linux/ppc64le, linux/arm/v6, linux/arm/v7 removed due to compatibility in pip
-          platforms: linux/amd64, linux/arm64/v8, linux/s390x
+          # linux/386, linux/ppc64le, linux/arm/v6, linux/arm/v7, linux/s390x removed due to compatibility in pip
+          platforms: linux/amd64, linux/arm64/v8
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation for GHCR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,8 +84,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Support everything in https://hub.docker.com/_/python
-          # linux/386 removed due to compatibility in pip
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
+          # linux/386, linux/ppc64le removed due to compatibility in pip
+          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/s390x
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation for GHCR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Support everything in https://hub.docker.com/_/python
-          platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
+          # linux/386 removed due to compatibility in pip
+          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation for GHCR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,8 +84,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Support everything in https://hub.docker.com/_/python
-          # linux/386, linux/ppc64le removed due to compatibility in pip
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/s390x
+          # linux/386, linux/ppc64le, linux/arm/v7 removed due to compatibility in pip
+          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8, linux/s390x
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation for GHCR

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3-alpine
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt -r web-requirements.txt
+
+EXPOSE 5004
+
+VOLUME /config
+
+USER 1000:1000
+
+# Automatically create the basic config file if it doesn't exist - makes life from Docker easier
+CMD ([ ! -e /config/config.ini ] && python tdarr_inform.py --config /config/config.ini --setup) && python tdarr_inform.py --config /config/config.ini --mode server

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ title="PayPal – The safer, easier way to pay online!" border="0" />
 
 ## Usage
 
-There are 3 ways to use this program.
+There are 4 ways to use this program.
+
 * The original way uses the Custom Script functionality of Sonarr/Radarr/Whisparr.
 * You can also run it via CLI, but this is mostly for testing, and I haven't documented this yet.
 * The NEW MODE is to run it with the `--mode server` argument.
+* You can use this within Docker where it automatically runs in Server Mode.
 
-NOTE:
-* Sonarr/Radarr/Whisparr file paths must be accessible to Tdarr. This script does not currently "translate" paths. This may be added in the future.
-
+> [!NOTE]
+> Sonarr/Radarr/Whisparr file paths must be accessible to Tdarr. This script does not currently "translate" paths. This may be added in the future.
 
 ## Installation
 
@@ -50,6 +51,7 @@ For Standalone, you are done. For server mode
 ### Standalone Script
 
 ## Add to Sonarr/Radarr/Whisparr
+
 1) Go to Settings/Connect
 2) Add
 3) Custom Script
@@ -58,8 +60,38 @@ For Standalone, you are done. For server mode
 
 6) You might see permissions issues for the script if your sonarr user doesnt have permission to run it. `chown` it to your needs.
 
+## Docker
 
-# Why this exists
+This can be used in Server Mode from within Docker where it will automatically create a `/config/config.ini` file if needed. It is important to mount the config folder elsewhere so your settings don't get lost if this is updated.
+
+The examples listed below are very basic, and will run if tdarr is also running locally. In reality you should attach to the same network as tdarr (and update the settings to point at the correct hostname etc).
+
+### docker-compose (recommended)
+
+```yml
+services:
+  tdarr_inform:
+    image: ghcr.io/deathbybandaid/tdarr_inform:latest
+    restart: unless-stopped
+    network_mode: host
+    ports:
+      - "5004:5004"
+    volumes:
+      - "/path/to/config:/config"
+```
+
+### docker cli
+
+```sh
+docker run -d \
+  -p 5004:5004 \
+  -v /path/to/config:/config \
+  --restart unless-stopped \
+  --network=host \
+  ghcr.io/deathbybandaid/tdarr_inform:latest
+```
+
+## Why this exists
 
 Tdarr is able to listen to filesystem events and/or scan the filesystem periodically.
 


### PR DESCRIPTION
This adds Docker support, with a basic example added to the README, and a github action to automatically build & push the docker image whenever the master branch is updated (if you add the relevant secrets you can uncomment the lines to push to docker hub too - also needs the `env.IMAGE_NAME` line 59 uncommented and moved down one).

On a technical point in the Dockerfile - it creates a `/config` mount, and points the config file at that, so outside of the container there is access to the file - this also means the config will survive fresh installs (it might be an idea to move the data files into that too, but I don't know the internals and what might be needed). When it starts up it checks if the config.ini file exists, and if not will run once with the `--setup` argument to create it, before running the Server Mode properly.