### PR TITLE
Improved docker support and example config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ EXPOSE 5004
 
 VOLUME /config
 
+HEALTHCHECK --start-period=30s --timeout=5s CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:5004/ || exit 1
+
 USER 1000:1000
 
 # Automatically create the basic config file if it doesn't exist - makes life from Docker easier
-CMD ([ ! -e /config/config.ini ] && python tdarr_inform.py --config /config/config.ini --setup) ; python tdarr_inform.py --config /config/config.ini --mode server
+CMD ([ ! -e /config/config.ini ] && python tdarr_inform.py --config /config/config.ini --setup && chmod a+rw /config/config.ini) ; python tdarr_inform.py --config /config/config.ini --mode server

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ services:
     image: ghcr.io/deathbybandaid/tdarr_inform:latest
     restart: unless-stopped
     network_mode: host
+    user: "1000:1000" # This is the same as the default
     ports:
       - "5004:5004"
     volumes:
@@ -90,6 +91,54 @@ docker run -d \
   --network=host \
   ghcr.io/deathbybandaid/tdarr_inform:latest
 ```
+
+## Config file
+
+This is a copy of the file created by the `--config` option:
+
+<details>
+<summary>Default config</summary>
+
+```ini
+[logging]
+level = INFO
+format = None
+
+[database]
+type = sqlite
+driver = None
+user = None
+pass = None
+host = None
+port = None
+name = None
+
+[main]
+cache_dir = None
+
+[tdarr_inform]
+address = 0.0.0.0
+port = 5004
+require_auth = None
+friendlyname = tdarr_inform
+versions_check_interval = 10800
+humanized_time_granularity = second
+
+[tdarr]
+address = localhost
+port = 8265
+ssl = None
+accept_root_drive_path = 1
+
+[web_ui]
+theme = None
+access_level = None
+auto_page_refresh = 5
+pages_to_refresh = None
+```
+
+</details>
+
 
 ## Why this exists
 


### PR DESCRIPTION
Fixes #34 

Added a HEALTHCHECK to the container so docker can see if it is healthy, and ensured that the automatically created config file has appropriate permissions.

Also added a copy of the created config file to the readme for reference