### PR TITLE
Dockerfile to handle permissions of log files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ VOLUME /config
 
 HEALTHCHECK --start-period=30s --timeout=5s CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:5004/ || exit 1
 
+USER root
+
+RUN chown -R 1000:1000 /app/data/cache
+
 USER 1000:1000
 
 # Automatically create the basic config file if it doesn't exist - makes life from Docker easier


### PR DESCRIPTION
To resolve issue #34 .

Dockerfile permissions to chown /app/data/cache so the script can write logs.